### PR TITLE
Add Australia as sending country for Remit Choice

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -16,6 +16,13 @@
         "operating_countries": [
           "GB"
         ]
+      },
+      {
+        "sending_currency": "AUD",
+        "representative_country": "AUS",
+        "operating_countries": [
+          "AU"
+        ]
       }
     ],
     "receiving_countries": [


### PR DESCRIPTION
## Summary
- include Australia as a sending country using AUD and representative code AUS
- keep receiving country list consistent with existing GB, MT, and NL operations

## Testing
- `python -m json.tool providers.json >/tmp/providers_fmt.json && tail -n +1 /tmp/providers_fmt.json`

------
https://chatgpt.com/codex/tasks/task_e_68b76d1f8d1483248d1c7ab1aeb66f8a